### PR TITLE
Script updates to support menu-config-update

### DIFF
--- a/deb-eeprom
+++ b/deb-eeprom
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Description: get latest eeprom
 # Destination: /usr/local/bin/deb-eeprom
 
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/deb-eeprom
+++ b/deb-eeprom
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Destination: /usr/local/bin/swh
+
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 DOWNLOAD="aria2c -c --download-result=hide --console-log-level=error --disable-ipv6=true --summary-interval=0 --show-files=false"
 PATCHES="https://raw.githubusercontent.com/pyavitz/rpi-img-builder/master/files/patches/"

--- a/deb-eeprom
+++ b/deb-eeprom
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Destination: /usr/local/bin/swh
+# Destination: /usr/local/bin/deb-eeprom
 
 export PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 DOWNLOAD="aria2c -c --download-result=hide --console-log-level=error --disable-ipv6=true --summary-interval=0 --show-files=false"

--- a/governor
+++ b/governor
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Destination: /usr/local/bin/governor
+
 GOVERNOR="performance"
 FIND=`command -v governor`
 DIR="/usr/local/bin/"

--- a/governor
+++ b/governor
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Description: Set governor scheduler
 # Destination: /usr/local/bin/governor
 
 GOVERNOR="performance"

--- a/swh
+++ b/swh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # Description: WiFi config helper
 # Destination: /usr/local/bin/swh
-# Service: ssh
 
 INTERFACE="wlan0"
 FIND=`command -v swh`

--- a/swh
+++ b/swh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
+# Description: WiFi config helper
 # Destination: /usr/local/bin/swh
 # Service: ssh
+
 INTERFACE="wlan0"
 FIND=`command -v swh`
 DIR="/usr/local/bin/"

--- a/swh
+++ b/swh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Destination: /usr/local/bin/swh
+# Service: ssh
 INTERFACE="wlan0"
 FIND=`command -v swh`
 DIR="/usr/local/bin/"

--- a/swh
+++ b/swh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Destination: /usr/local/bin/swh
 INTERFACE="wlan0"
 FIND=`command -v swh`
 DIR="/usr/local/bin/"

--- a/update-fw
+++ b/update-fw
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Raspberry Pi Firmware
+# Description: Update Raspberry Pi Firmware
 # Destination: /usr/local/bin/update-fw
 RED="\e[1;31m"
 FIN="\e[0m"

--- a/update-fw
+++ b/update-fw
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Raspberry Pi Firmware
+# Destination: /usr/local/bin/update-fw
 RED="\e[1;31m"
 FIN="\e[0m"
 

--- a/write2usb
+++ b/write2usb
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Description: Write operational image to usb
 # Destination: /usr/local/bin/write2usb
 
 USB="/dev/sda"

--- a/write2usb
+++ b/write2usb
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Destination: /usr/local/bin/write2usb
+
 USB="/dev/sda"
 ERROR="$(ls {/dev/sdb,/dev/sdc,/dev/sdd} 2> /dev/null)"
 PI_EEPROM="pieeprom-2021-12-02"


### PR DESCRIPTION
Added comment lines into 5 of the scripts that are included in the debian build.  Can have Three comments, 1st two are required, service is only needed if a service should be restated by systemctl after the file is put in place.
```
# Description: WiFi config helper
# Destination: /usr/local/bin/swh
# Service: ssh
```
This is first step in support new menu-config-update script.  If approach is acceptable I'll be updating the script in the debian-image-builder.